### PR TITLE
UIWebView call loadRequest multiple times lead to deadlock in iOS12

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m
@@ -329,9 +329,13 @@ static NSString *stripFragment(NSString* url)
             break;
 
         case STATE_WAITING_FOR_LOAD_FINISH:
-            if (_loadCount == 1) {
+            if (@available(iOS 12.0, *)){
                 fireCallback = YES;
-                _state = STATE_IDLE;
+            } else {
+                if (_loadCount == 1) {
+                    fireCallback = YES;
+                    _state = STATE_IDLE;
+                }
             }
             _loadCount -= 1;
             break;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
* iOS 12

### What does this PR do?

  *  Forces iOS 12 to fire callback in webViewDidFinish to disable
  the splash screen and load the webview for the app.
  *  Fix ported from: https://github.com/apache/cordova-ios/pull/450

### What testing has been done on this change?


### Checklist